### PR TITLE
Simplified izpisi_velikost function

### DIFF
--- a/2023/1. Skupina/naloga-2.py
+++ b/2023/1. Skupina/naloga-2.py
@@ -38,47 +38,14 @@ Primeri:
 # Naslednja rešitev je narejena z uporabo podprogramom.
 #######################################################
 
-def izpisi_velikost(velikost): # Definiramo glavni podprogram, ki bo pravilno izpisal velikost.
-    ostanek = 0 # Definiramo ostanek ki nam bo pomagal pri popolnem izpisu velikosti ki se usklaja z nalogo.
+def izpisi_velikost(velikost, _ostanek = 0, _prefix_i = 0):
+    prefix = ["B", "KB", "MB", "GB", "TB", "PB", "EB"]
 
-    #########################################################
-    # V podprogramu imamo vsepovsod v if stavkih "< 1", saj
-    # je v nalogi navedeno če je rezultat več kot 4 številčni,
-    # se naj izpiše v preponi ki sledi trenutni.
-    #########################################################
+    if velikost >= 10000 and _prefix_i < len(prefix):
+        return izpisi_velikost(velikost / 1024, ostanekPlus(velikost % 1024), _prefix_i + 1)
+    return str(int(velikost) + _ostanek) + " " + prefix[_prefix_i]
 
-    if velikost < 10000:
-        return str(velikost) + " B"
-    else:
-        ostanek = velikost % 1024
-        velikost /= 1024
 
-        if velikost < 10000:
-            return str(round(velikost) + ostanek) + " KB"
-        else:
-            ostanek = ostanekPlus(velikost % 1024)
-            velikost /= 1024
-            if velikost < 10000:
-                return str(round(velikost) + ostanek) + " MB"
-            else:
-                ostanek = ostanekPlus(velikost % 1024)
-                velikost /= 1024
-                if velikost < 10000:
-                    return str(round(velikost) + ostanek) + " GB"
-                else:
-                    ostanek = ostanekPlus(velikost % 1024)
-                    velikost /= 1024
-                    if velikost < 10000:
-                        return str(round(velikost) + ostanek) + " TB"
-                    else:
-                        ostanek = ostanekPlus(velikost % 1024)
-                        velikost /= 1024
-                        if velikost < 10000:
-                            return str(round(velikost) + ostanek) + " PB"
-                        else:
-                            return str(round(velikost) + ostanek) + " EB"
-
-    
 
 # Uporaba naslednjega podprograma je da se odločimo če bomo pripisali rezultatu 1 ali ne.
 # V navodilih naloge je napisano naslednje:


### PR DESCRIPTION
Made a simpler version of the `izpisi_velikost` function and tested it with the following test samples:
```
| podatek   | izpis    |
| 0         | 0 B      |
| 5678      | 5678 B   |
| 2097152   | 2048 KB  |
| 2097153   | 2049 KB  |
| 12897500  | 13 MB    |
| 128975000 | 124 MB   |
```

This version also seams to calculate a proper result for `10000`:

```
Vnesi velikost datoteke: 10000
Old function: 794 KB
New function: 10 KB
```